### PR TITLE
chore: optimize avoid stringify

### DIFF
--- a/src/useIntersectionObserver.ts
+++ b/src/useIntersectionObserver.ts
@@ -37,7 +37,7 @@ function useIntersectionObserver(
         observer.disconnect();
       };
     },
-    [rootMargin, JSON.stringify(threshold)],
+    [rootMargin, threshold ? threshold.toString() : "0"],
     [root, target]
   );
 }


### PR DESCRIPTION
For the useIntersectionObserver hook, use `toString` instead of `JSON.stringify`.

Benchmark performance is quite great when dealing with single number, not much difference if attempting to stringify array.

Note that threshold values of `undefined`, `0`, `null` or `[0]` or anything falsey will result in a value of `"0"` which is the default threshold value for IntersectionObserver. However, for simplicity it will not account for empty array case `[]`, which can still yield an unintended effect reset+re-init.

https://www.measurethat.net/Benchmarks/Show/27907/0/json-stringify-vs-object-tostring-number-thresholds